### PR TITLE
release agntcy-slim-mcp-proxy-v0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mcp-proxy"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/agntcy/slim-mcp-rust/compare/slim-mcp-proxy-v0.2.4...slim-mcp-proxy-v0.2.5) - 2026-04-07
+
+### Added
+
+- improve identity configuration ([#40](https://github.com/agntcy/slim-mcp-rust/pull/40))
+
+### Fixed
+
+- make test work with new version of rmcp ([#36](https://github.com/agntcy/slim-mcp-rust/pull/36))
+
 ## [0.2.4](https://github.com/agntcy/slim-mcp-rust/compare/slim-mcp-proxy-v0.2.3...slim-mcp-proxy-v0.2.4) - 2026-04-02
 
 ### Added

--- a/mcp-proxy/Cargo.toml
+++ b/mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-mcp-proxy"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 license = "Apache-2.0"
 description = "Proxy for exposing a native MCP server over SLIM"

--- a/mcp-proxy/examples/k8s-test/mcp-server-config/kubernetes-mcp-server-values.yaml
+++ b/mcp-proxy/examples/k8s-test/mcp-server-config/kubernetes-mcp-server-values.yaml
@@ -1,25 +1,76 @@
 # Kubernetes MCP Server Helm values
 # RBAC permissions for accessing resources in mcp-system namespace
 
+# Disable ingress (not needed for SLIM proxy setup)
 ingress:
   enabled: false
 
+# RBAC configuration for cluster-wide read access
 rbac:
-  # Create a Role in mcp-system namespace with permissions to list/get pods, services, events
-  extraRoles:
-  - name: mcp-system-reader
-    namespace: mcp-system
-    rules:
-    - apiGroups: [""]
-      resources: ["pods", "services", "events"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: [""]
-      resources: ["pods/log"]
-      verbs: ["get"]
-  
-  # Bind the Role to the kubernetes-mcp-server ServiceAccount
-  extraRoleBindings:
-  - name: mcp-system-reader
-    namespace: mcp-system
-    roleRef:
-      name: mcp-system-reader
+  # Create ClusterRole with read permissions across the entire cluster
+  extraClusterRoles:
+    - name: kubernetes-mcp-server-reader
+      rules:
+        # Core Kubernetes resources (needed by default "core" toolset)
+        - apiGroups: [""]
+          resources:
+            - pods
+            - pods/log
+            - pods/status
+            - services
+            - endpoints
+            - events
+            - namespaces
+            - nodes
+            - persistentvolumes
+            - persistentvolumeclaims
+            - configmaps  # Optional: if you want to read configs
+            - secrets     # Optional: be careful with this
+          verbs: ["get", "list", "watch"]
+        
+        # Apps resources (deployments, replicasets, etc.)
+        - apiGroups: ["apps"]
+          resources:
+            - deployments
+            - replicasets
+            - statefulsets
+            - daemonsets
+          verbs: ["get", "list", "watch"]
+        
+        # Batch resources (jobs, cronjobs)
+        - apiGroups: ["batch"]
+          resources:
+            - jobs
+            - cronjobs
+          verbs: ["get", "list", "watch"]
+        
+        # Networking resources
+        - apiGroups: ["networking.k8s.io"]
+          resources:
+            - ingresses
+            - networkpolicies
+          verbs: ["get", "list", "watch"]
+
+  # Bind the ClusterRole to the kubernetes-mcp-server ServiceAccount
+  extraClusterRoleBindings:
+    - name: kubernetes-mcp-server-reader-binding
+      roleRef:
+        name: kubernetes-mcp-server-reader
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+      # The serviceAccountName will be automatically filled by the Helm chart
+      # It will be: <release-name>-kubernetes-mcp-server
+
+# Optional: Enable only the toolsets you need
+# By default, "config" and "core" are enabled
+# Uncomment to explicitly set:
+# config:
+#   toolsets: "core,config"
+
+# Optional: Run in read-only mode to prevent any modifications
+# config:
+#   readOnly: true
+
+# Optional: Disable destructive operations
+# config:
+#   disableDestructive: true


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-mcp-proxy`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.5](https://github.com/agntcy/slim-mcp-rust/compare/slim-mcp-proxy-v0.2.4...slim-mcp-proxy-v0.2.5) - 2026-04-07

### Added

- improve identity configuration ([#40](https://github.com/agntcy/slim-mcp-rust/pull/40))

### Fixed

- make test work with new version of rmcp ([#36](https://github.com/agntcy/slim-mcp-rust/pull/36))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).