### PR TITLE
release agntcy-slim-mcp-proxy-v0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mcp-proxy"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",

--- a/mcp-proxy/CHANGELOG.md
+++ b/mcp-proxy/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/agntcy/slim-mcp-rust/compare/slim-mcp-proxy-v0.2.5...slim-mcp-proxy-v0.2.6) - 2026-08-14
+
+### Other
+
+- *(deps)* upgrade SLIM to 2.0.0 and Rust MCP SDK (rmcp) to 3.1.1 ([#45](https://github.com/agntcy/slim-mcp-rust/pull/45))
+
 ## [0.2.5](https://github.com/agntcy/slim-mcp-rust/compare/slim-mcp-proxy-v0.2.4...slim-mcp-proxy-v0.2.5) - 2026-04-07
 
 ### Added

--- a/mcp-proxy/Cargo.toml
+++ b/mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-slim-mcp-proxy"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 license = "Apache-2.0"
 description = "Proxy for exposing a native MCP server over SLIM"


### PR DESCRIPTION



## 🤖 New release

* `agntcy-slim-mcp-proxy`: 0.2.5 -> 0.2.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.6](https://github.com/agntcy/slim-mcp-rust/compare/slim-mcp-proxy-v0.2.5...slim-mcp-proxy-v0.2.6) - 2026-08-14

### Other

- *(deps)* upgrade SLIM to 2.0.0 and Rust MCP SDK (rmcp) to 3.1.1 ([#45](https://github.com/agntcy/slim-mcp-rust/pull/45))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).